### PR TITLE
fix(controlnet): Use correct preprocessor node names (Issues #17, #18)

### DIFF
--- a/src/tools/controlnet.test.ts
+++ b/src/tools/controlnet.test.ts
@@ -619,7 +619,7 @@ describe("generateWithComposition", () => {
     const calledWorkflow = queueSpy.mock.calls[0][0];
     expect(calledWorkflow["20"]).toBeDefined();
     expect(calledWorkflow["20"].class_type).toBe(
-      "OneFormer-ADE20K-SemSegPreprocessor"
+      "UniFormer-SemSegPreprocessor"
     );
   });
 });

--- a/src/workflows/builder.ts
+++ b/src/workflows/builder.ts
@@ -254,10 +254,11 @@ function getPreprocessorClass(type: ControlNetType): string | null {
     case "openpose":
       return "DWPreprocessor";
     case "scribble":
+      return "ScribblePreprocessor";
     case "lineart":
-      return "AnyLineArtPreprocessor";
+      return "LineArtPreprocessor";
     case "semantic_seg":
-      return "OneFormer-ADE20K-SemSegPreprocessor";
+      return "UniFormer-SemSegPreprocessor";
     case "qrcode":
       return null; // QR Code doesn't need preprocessing
     default:


### PR DESCRIPTION
## Summary

Fixes ControlNet preprocessor failures caused by incorrect node class names.

### Issue #17: AnyLineArtPreprocessor doesn't exist
**Affected tools**: `preprocess_control_image` (lineart/scribble), `stylize_photo`

**Fix**:
- `lineart`: `AnyLineArtPreprocessor` → `LineArtPreprocessor`
- `scribble`: `AnyLineArtPreprocessor` → `ScribblePreprocessor`

### Issue #18: semantic_seg timeout
**Affected tools**: `preprocess_control_image` (semantic_seg), `generate_with_composition`

**Fix**:
- `semantic_seg`: `OneFormer-ADE20K-SemSegPreprocessor` → `UniFormer-SemSegPreprocessor`
- UniFormer is lighter and faster, avoiding the ~2GB OneFormer model download/load timeout

## Research

Node names verified against [comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux) documentation.

## Test Plan

- [x] All 745 tests pass
- [x] Updated test expectations for new node names

## Files Changed

| File | Change |
|------|--------|
| `src/workflows/builder.ts` | Fix `getPreprocessorClass()` return values |
| `src/tools/controlnet.test.ts` | Update test expectation for UniFormer |

Fixes #17
Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)